### PR TITLE
Expose run_tests & run_tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "bitflags"
@@ -115,9 +115,9 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cc"
@@ -136,7 +136,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfspeedtest"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "clap",
  "csv",
@@ -515,9 +515,9 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "log"
@@ -709,9 +709,9 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.11"
+version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0c3dde1fc030af041adc40e79c0e7fbcf431dd24870053d187d7c66e4b87453"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
 dependencies = [
  "bitflags",
  "errno",
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "2cc66a619ed80bf7a0f6b17dd063a84b88f6dea1813737cf469aef1d081142c2"
 dependencies = [
  "itoa",
  "ryu",
@@ -853,9 +853,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.31"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfspeedtest"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 license = "MIT"
 description = "Unofficial CLI for speed.cloudflare.com"

--- a/src/measurements.rs
+++ b/src/measurements.rs
@@ -19,9 +19,9 @@ struct StatMeasurement {
 
 #[derive(Serialize)]
 pub struct Measurement {
-    pub(crate) test_type: TestType,
-    pub(crate) payload_size: usize,
-    pub(crate) mbit: f64,
+    pub test_type: TestType,
+    pub payload_size: usize,
+    pub mbit: f64,
 }
 
 impl Display for Measurement {

--- a/src/speedtest.rs
+++ b/src/speedtest.rs
@@ -50,7 +50,7 @@ impl PayloadSize {
         }
     }
 
-    fn sizes_from_max(max_payload_size: PayloadSize) -> Vec<usize> {
+    pub fn sizes_from_max(max_payload_size: PayloadSize) -> Vec<usize> {
         log::debug!("getting payload iterations for max_payload_size {max_payload_size:?}");
         let payload_bytes: Vec<usize> =
             vec![100_000, 1_000_000, 10_000_000, 25_000_000, 100_000_000];
@@ -170,7 +170,7 @@ pub fn test_latency(client: &Client) -> f64 {
     req_latency
 }
 
-fn run_tests(
+pub fn run_tests(
     client: &Client,
     test_fn: fn(&Client, usize, OutputFormat) -> f64,
     test_type: TestType,


### PR DESCRIPTION
When using crate as a library, it's currently not possible to get to the measurement data, unless we parse `Measurement::fmt()` string. Exposing those struct fields solves the issue.

Additionally, `fn speed_test` exposes download/upload speeds, but not latency data. We need to run speed and latency tests separately, to get the data from both, which requires making `run_tests` public.
_(Using `test_upload/download` would also work, but `run_tests` takes care of running multiple tests for different payload sizes, which would otherwise need to be reimplemented in the downstream crate.)_