### PR TITLE
ci: build and push arm64

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
+          platforms: linux/amd64,linux/arm64
           push: false
           tags: |
             cybuerg/cfspeedtest:${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             cybuerg/cfspeedtest:${{ github.ref_name }}


### PR DESCRIPTION
This pull request ensures that the arm64 Docker image is built and pushed along the (default) amd64 Docker image.

**Notes**:
- This is pretty slow because the `arm64` container is built on an amd64 host (the GitHub runner). IMO it's definitely worth running for releases, but we may want to revert the changes to `.github/workflows/CI.yml`.
- Alternatively we could cross build the arm64 binary with the Rust toolchain inside an amd64 container, and then create an arm64 container where we copy the binary. See [this article](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/#93cb) from Docker blog.

# How to reproduce

```shell
ubuntu@ubuntu:~$ docker run cybuerg/cfspeedtest
Unable to find image 'cybuerg/cfspeedtest:latest' locally
latest: Pulling from cybuerg/cfspeedtest
docker: no matching manifest for linux/arm64/v8 in the manifest list entries.
See 'docker run --help'.
```

# System configuration
 
<img width="599" alt="image" src="https://github.com/code-inflation/cfspeedtest/assets/2824100/929ddfb5-09f5-436b-8a26-6511970bf12c">



