### PR TITLE
feat: allow users to use --ipv{4,6} flags to bind to other addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Options:
           Set the output format [csv, json or json-pretty] > This silences all other output to stdout [default: StdOut]
   -v, --verbose
           Enable verbose output i.e. print boxplots of the measurements
-      --ipv4
-          Force usage of IPv4
-      --ipv6
-          Force usage of IPv6
+      --ipv4 [<IPv4>]
+          Force IPv4 with provided source IPv4 address or the default IPv4 address bound to the main interface
+      --ipv6 [<IPv6>]
+          Force IPv6 with provided source IPv6 address or the default IPv6 address bound to the main interface
   -d, --disable-dynamic-max-payload-size
           Disables dynamically skipping tests with larger payload sizes if the tests for the previous payload size took longer than 5 seconds
       --download-only

--- a/examples/simple_speedtest.rs
+++ b/examples/simple_speedtest.rs
@@ -7,8 +7,8 @@ fn main() {
     // define speedtest options
     let options = SpeedTestCLIOptions {
         output_format: OutputFormat::None, // don't write to stdout
-        ipv4: false,                       // don't force ipv4 usage
-        ipv6: false,                       // don't force ipv6 usage
+        ipv4: None,                        // don't force ipv4 usage
+        ipv6: None,                        // don't force ipv6 usage
         verbose: false,
         upload_only: false,
         download_only: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,13 +61,13 @@ pub struct SpeedTestCLIOptions {
     #[arg(short, long)]
     pub verbose: bool,
 
-    /// Force usage of IPv4
-    #[arg(long)]
-    pub ipv4: bool,
+    /// Force IPv4 with provided source IPv4 address or the default IPv4 address bound to the main interface
+    #[clap(long, value_name = "IPv4", num_args = 0..=1, default_missing_value = "0.0.0.0", conflicts_with = "ipv6")]
+    pub ipv4: Option<String>,
 
-    /// Force usage of IPv6
-    #[arg(long)]
-    pub ipv6: bool,
+    /// Force IPv6 with provided source IPv6 address or the default IPv6 address bound to the main interface
+    #[clap(long, value_name = "IPv6", num_args = 0..=1, default_missing_value = "::", conflicts_with = "ipv4")]
+    pub ipv6: Option<String>,
 
     /// Disables dynamically skipping tests with larger payload sizes if the tests for the previous payload
     /// size took longer than 5 seconds

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,13 +27,13 @@ fn main() {
         println!("Starting Cloudflare speed test");
     }
     let client;
-    if options.ipv4 {
+    if let Some(ref ip) = options.ipv4 {
         client = reqwest::blocking::Client::builder()
-            .local_address("0.0.0.0".parse::<IpAddr>().unwrap())
+            .local_address(ip.parse::<IpAddr>().expect("Invalid IPv4 address"))
             .build();
-    } else if options.ipv6 {
+    } else if let Some(ref ip) = options.ipv6 {
         client = reqwest::blocking::Client::builder()
-            .local_address("::".parse::<IpAddr>().unwrap())
+            .local_address(ip.parse::<IpAddr>().expect("Invalid IPv6 address"))
             .build();
     } else {
         client = reqwest::blocking::Client::builder().build();


### PR DESCRIPTION
Instead of using default outbound address all the time, change the bool flag to an optional of string

If the flag is set but no value is given, use default (0.0.0.0 or ::)

If the flag is set and a value is given, bind to that address