### PR TITLE
Use native ARM64 runners for faster Docker builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,16 +30,23 @@ jobs:
     - name: Run CLI
       run: cargo run
 
-  docker-build:
+  docker-build-amd64:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build and push Docker image
+      - name: Build AMD64 Docker image
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: false
           tags: |
-            cybuerg/cfspeedtest:${{ github.sha }}
+            cybuerg/cfspeedtest:${{ github.sha }}-amd64
+
+  docker-build-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build ARM64 Docker image
+        run: docker build --platform linux/arm64 -t cybuerg/cfspeedtest:${{ github.sha }}-arm64 .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
           zip: windows
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  docker-build-and-push:
+  docker-build-amd64:
     needs: [create-release, upload-assets]
     runs-on: ubuntu-latest
     steps:
@@ -57,11 +57,50 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push Docker image
+      - name: Build and push AMD64 Docker image
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
-            cybuerg/cfspeedtest:${{ github.ref_name }}
-            cybuerg/cfspeedtest:latest
+            cybuerg/cfspeedtest:${{ github.ref_name }}-amd64
+            cybuerg/cfspeedtest:latest-amd64
+
+  docker-build-arm64:
+    needs: [create-release, upload-assets]
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push ARM64 Docker image
+        run: |
+          docker build --platform linux/arm64 -t cybuerg/cfspeedtest:${{ github.ref_name }}-arm64 -t cybuerg/cfspeedtest:latest-arm64 .
+          docker push cybuerg/cfspeedtest:${{ github.ref_name }}-arm64
+          docker push cybuerg/cfspeedtest:latest-arm64
+
+  docker-create-manifest:
+    needs: [docker-build-amd64, docker-build-arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Create and push multi-arch manifest
+        run: |
+          # Create manifest for versioned tag
+          docker manifest create cybuerg/cfspeedtest:${{ github.ref_name }} \
+            cybuerg/cfspeedtest:${{ github.ref_name }}-amd64 \
+            cybuerg/cfspeedtest:${{ github.ref_name }}-arm64
+          docker manifest push cybuerg/cfspeedtest:${{ github.ref_name }}
+          
+          # Create manifest for latest tag
+          docker manifest create cybuerg/cfspeedtest:latest \
+            cybuerg/cfspeedtest:latest-amd64 \
+            cybuerg/cfspeedtest:latest-arm64
+          docker manifest push cybuerg/cfspeedtest:latest


### PR DESCRIPTION
## Summary
- Split Docker builds to use native ARM64 GitHub runners instead of cross-compilation
- Separate jobs for AMD64 (ubuntu-latest) and ARM64 (arm64-linux) builds
- Added manifest creation job to maintain multi-arch Docker images