### PR TITLE
Cache cargo-audit installation for faster security checks

### DIFF
--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -15,8 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Cache cargo-audit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-${{ runner.os }}-v0.21.2
       - name: Install cargo audit
-        run: cargo install cargo-audit
+        run: |
+          if ! command -v cargo-audit &> /dev/null; then
+            cargo install cargo-audit
+          fi
       - name: Run Cargo Audit
         run: cargo audit
     continue-on-error: true


### PR DESCRIPTION
## Summary
- Add caching for cargo-audit binary installation
- Skip installation if binary already exists in cache
- Use specific version key for consistent caching