### PR TITLE
Fix IPv6 connection timeout panic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,13 +30,17 @@ fn main() {
     if let Some(ref ip) = options.ipv4 {
         client = reqwest::blocking::Client::builder()
             .local_address(ip.parse::<IpAddr>().expect("Invalid IPv4 address"))
+            .timeout(std::time::Duration::from_secs(30))
             .build();
     } else if let Some(ref ip) = options.ipv6 {
         client = reqwest::blocking::Client::builder()
             .local_address(ip.parse::<IpAddr>().expect("Invalid IPv6 address"))
+            .timeout(std::time::Duration::from_secs(30))
             .build();
     } else {
-        client = reqwest::blocking::Client::builder().build();
+        client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build();
     }
     speed_test(
         client.expect("Failed to initialize reqwest client"),

--- a/src/speedtest.rs
+++ b/src/speedtest.rs
@@ -83,7 +83,13 @@ impl Display for Metadata {
 }
 
 pub fn speed_test(client: Client, options: SpeedTestCLIOptions) -> Vec<Measurement> {
-    let metadata = fetch_metadata(&client);
+    let metadata = match fetch_metadata(&client) {
+        Ok(metadata) => metadata,
+        Err(e) => {
+            eprintln!("Error fetching metadata: {}", e);
+            std::process::exit(1);
+        }
+    };
     if options.output_format == OutputFormat::StdOut {
         println!("{metadata}");
     }
@@ -284,21 +290,16 @@ fn print_current_speed(
     );
 }
 
-pub fn fetch_metadata(client: &Client) -> Metadata {
+pub fn fetch_metadata(client: &Client) -> Result<Metadata, reqwest::Error> {
     let url = &format!("{}/{}{}", BASE_URL, DOWNLOAD_URL, 0);
-    let headers = client
-        .get(url)
-        .send()
-        .expect("failed to get response")
-        .headers()
-        .to_owned();
-    Metadata {
+    let headers = client.get(url).send()?.headers().to_owned();
+    Ok(Metadata {
         city: extract_header_value(&headers, "cf-meta-city", "City N/A"),
         country: extract_header_value(&headers, "cf-meta-country", "Country N/A"),
         ip: extract_header_value(&headers, "cf-meta-ip", "IP N/A"),
         asn: extract_header_value(&headers, "cf-meta-asn", "ASN N/A"),
         colo: extract_header_value(&headers, "cf-meta-colo", "Colo N/A"),
-    }
+    })
 }
 
 fn extract_header_value(
@@ -452,10 +453,22 @@ mod tests {
 
     #[test]
     fn test_payload_size_display() {
-        // The Display implementation uses format_bytes from measurements module
-        // We'll test the basic functionality
         let size = PayloadSize::K100;
         let display_str = format!("{}", size);
         assert!(!display_str.is_empty());
+    }
+
+    #[test]
+    fn test_fetch_metadata_ipv6_timeout_error() {
+        use std::time::Duration;
+
+        let client = reqwest::blocking::Client::builder()
+            .local_address("::".parse::<std::net::IpAddr>().unwrap())
+            .timeout(Duration::from_millis(100))
+            .build()
+            .unwrap();
+
+        let result = fetch_metadata(&client);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Fixes panic when using `--ipv6` flag on networks with poor IPv6 connectivity
- Adds 30-second timeout to HTTP client
- Returns proper error instead of crashing