### PR TITLE
chore: consolidate dependency bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,18 +1590,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ exclude = [".github/"]
 [dependencies]
 log = "0.4"
 env_logger = "0.11"
-regex = "1.10"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
-clap = { version = "4.5.43", features = ["derive"] }
-serde = { version = "1.0.219", features = ["derive"] }
+regex = "1.12"
+reqwest = { version = "0.12.24", default-features = false, features = ["blocking", "rustls-tls"] }
+clap = { version = "4.5", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 csv = "1.3.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
-indexmap = "2.9.0"
+indexmap = "2.12"
 clap_complete = "4.5"


### PR DESCRIPTION
- consolidate dependabot bumps (clap, clap_complete, indexmap, regex, reqwest)
- relax manifests to minor ranges and refresh lock
- validated: fmt, clippy -D warnings, tests, examples, release build, real json run